### PR TITLE
Update from http to https

### DIFF
--- a/demos/mpeg-dash/demo.js
+++ b/demos/mpeg-dash/demo.js
@@ -1,5 +1,5 @@
 const playerInstance = jwplayer('player').setup({
-  playlist: 'http://cdn.jwplayer.com/v2/media/1g8jjku3?sources=mpd'
+  playlist: 'https://cdn.jwplayer.com/v2/media/1g8jjku3?sources=mpd'
 });
 
 


### PR DESCRIPTION
Loading a http in a https enabled site ( https://www.jwplayer.com/developers/web-player-demos/mpeg-dash/ ) leads to an error ( IDzF9Zmk.js:11 Mixed Content: The page at 'https://www.jwplayer.com/developers/web-player-demos/mpeg-dash/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://cdn.jwplayer.com/v2/media/1g8jjku3?sources=mpd'. This request has been blocked; the content must be served over HTTPS. )